### PR TITLE
Support for the Discourse skip_validations parameter and various other improvements

### DIFF
--- a/DiscourseApi/Api.cs
+++ b/DiscourseApi/Api.cs
@@ -77,6 +77,10 @@ namespace DiscourseApi {
 			if (typeof(ApiList).IsAssignableFrom(typeof(T))) {
 				JObject r = (getParameters == null ? (object)new ListRequest() : getParameters).ToJObject();
 				r["PostParameters"] = postParameters.ToJObject();
+				
+				if (Settings.SkipValidations)
+					r["PostParameters"].AddAfterSelf(new { skip_validations = Settings.SkipValidations });
+
 				j["Request"] = r;
 			}
 			return convertTo<T>(j);

--- a/DiscourseApi/Api.cs
+++ b/DiscourseApi/Api.cs
@@ -350,21 +350,18 @@ namespace DiscourseApi
                         }
                         else
                         {
-                            if (Settings.SkipValidations)
-                            {
-                                var postParamsList = postParameters.ToCollection().ToList();
-                                postParamsList.Add(new KeyValuePair<string, string>("skip_validations", "true"));
-                                content = postParamsList.ToJson();
-                                message.Content = disposeMe.Add(new FormUrlEncodedContent(postParamsList));
-                            }
-                            else
-                            {
-                                content = postParameters.ToJson();
-                                message.Content =
-                                    disposeMe.Add(new FormUrlEncodedContent(postParameters.ToCollection()));
-                            }
+                            var postParamsList = postParameters.ToCollection().ToList();
+                            var form = new MultipartFormDataContent();
 
-                        }
+							if (Settings.SkipValidations)
+								postParamsList.Add(new KeyValuePair<string, string>("skip_validations", "true"));
+
+                            foreach (var kvp in postParamsList)
+                                form.Add(new StringContent(kvp.Value), kvp.Key);
+
+                            content = postParamsList.ToJson();
+                            message.Content = disposeMe.Add(form);
+						}
                     }
                     else if (method != HttpMethod.Get && Settings.SkipValidations) 
                     {

--- a/DiscourseApi/Api.cs
+++ b/DiscourseApi/Api.cs
@@ -1,21 +1,16 @@
-﻿using System;
+﻿using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+using System.IO;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System.Threading;
-using System.Net.Sockets;
-using System.Net;
-using System.Diagnostics;
 using System.Text.RegularExpressions;
-using System.Runtime.InteropServices;
-using System.Linq;
-using System.IO;
+using System.Threading.Tasks;
 
-namespace DiscourseApi {
+namespace DiscourseApi
+{
 	public class Api : IDisposable {
 		HttpClient _client;
 

--- a/DiscourseApi/Category.cs
+++ b/DiscourseApi/Category.cs
@@ -1,8 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DiscourseApi {

--- a/DiscourseApi/Post.cs
+++ b/DiscourseApi/Post.cs
@@ -1,8 +1,6 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DiscourseApi {

--- a/DiscourseApi/Post.cs
+++ b/DiscourseApi/Post.cs
@@ -59,16 +59,16 @@ namespace DiscourseApi {
 		public int reviewable_score_count;
 		public int reviewable_score_pending_count;
 
-		static public async Task<PostStream> GetAll(Api api, int topicId) {
+		public static async Task<PostStream> GetAll(Api api, int topicId) {
 			JObject j = await api.GetAsync(Api.Combine("t", topicId, "posts"));
 			return j["post_stream"].ToObject<PostStream>();
 		}
 
-		static public async Task<Post> Get(Api api, int postId) {
+		public static async Task<Post> Get(Api api, int postId) {
 			return await api.GetAsync<Post>(Api.Combine("posts", postId));
 		}
 
-		static public async Task<Post> Create(Api api, int topicId, string message,
+		public static async Task<Post> Create(Api api, int topicId, string message,
 				string api_username = null, DateTime? created_at = null) {
 			return await api.PostAsync<Post>("posts", null, new {
 				topic_id = topicId,
@@ -78,13 +78,10 @@ namespace DiscourseApi {
 			});
 		}
 
-		static public async Task<Post> Update(Api api, int postId, string message) {
+		public static async Task<Post> Update(Api api, int postId, string message) {
 			JObject data = new JObject();
 			data["post[raw]"] = message;
 			return await api.PutAsync<Post>(Api.Combine("posts", postId), null, data);
 		}
-
-	}
-
-
+    }
 }

--- a/DiscourseApi/Post.cs
+++ b/DiscourseApi/Post.cs
@@ -83,5 +83,13 @@ namespace DiscourseApi {
 			data["post[raw]"] = message;
 			return await api.PutAsync<Post>(Api.Combine("posts", postId), null, data);
 		}
+
+		/// <summary>
+		/// Causes a post (topic or reply) to be rebuilt. Can help fix broken image issues.
+		/// </summary>
+        public static async Task<JObject> RebuildHtml(Api api, int postId)
+        {
+            return await api.PutAsync(Api.Combine("posts", postId, "rebake"));
+		}
     }
 }

--- a/DiscourseApi/Settings.cs
+++ b/DiscourseApi/Settings.cs
@@ -47,6 +47,10 @@ namespace DiscourseApi {
 		/// </summary>
 		void Save();
 
+		/// <summary>
+		/// Instructs Discourse to skip validaiton for the request. Can help bypass rate/spam prevention issues.
+		/// </summary>
+		bool SkipValidations { get; }
 	}
 
 	public class Settings : ISettings {
@@ -84,6 +88,11 @@ namespace DiscourseApi {
 		/// Larger numbers give more verbose logging.
 		/// </summary>
 		public int LogResult { get; set; }
+
+		/// <summary>
+		/// Instructs Discourse to skip validaiton for the request. Can help bypass rate/spam prevention issues.
+		/// </summary>
+		public bool SkipValidations { get; set; }
 
 		[JsonIgnore]
 		public string Filename;

--- a/DiscourseApi/Settings.cs
+++ b/DiscourseApi/Settings.cs
@@ -43,12 +43,12 @@ namespace DiscourseApi {
 		int DelayBetweenApiCalls { get; }
 
 		/// <summary>
-		/// After BaseCampApi has update tokens, save the infomation.
+		/// After BaseCampApi has update tokens, save the information.
 		/// </summary>
 		void Save();
 
 		/// <summary>
-		/// Instructs Discourse to skip validaiton for the request. Can help bypass rate/spam prevention issues.
+		/// Instructs Discourse to skip validation for the request. Can help bypass rate/spam prevention issues.
 		/// </summary>
 		bool SkipValidations { get; }
 	}
@@ -90,7 +90,7 @@ namespace DiscourseApi {
 		public int LogResult { get; set; }
 
 		/// <summary>
-		/// Instructs Discourse to skip validaiton for the request. Can help bypass rate/spam prevention issues.
+		/// Instructs Discourse to skip validation for the request. Can help bypass rate/spam prevention issues.
 		/// </summary>
 		public bool SkipValidations { get; set; }
 

--- a/DiscourseApi/Topic.cs
+++ b/DiscourseApi/Topic.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DiscourseApi {
@@ -173,12 +172,12 @@ namespace DiscourseApi {
 		public string last_poster_username;
 		public List<JToken> posters;
 
-		static public async Task<TopicListReturn> ListAll(Api api, int categoryId, int? parentCategoryId = null) {
+		public static async Task<TopicListReturn> ListAll(Api api, int categoryId, int? parentCategoryId = null) {
 			return await api.GetAsync<TopicListReturn>(parentCategoryId > 0 ?
 				Api.Combine("c", (int)parentCategoryId, categoryId) : Api.Combine("c", categoryId));
 		}
 
-		static public async Task<Post> Create(Api api, int categoryId, string title, string message, 
+		public static async Task<Post> Create(Api api, int categoryId, string title, string message, 
 				string api_username = null, DateTime? created_at = null) {
 			return await api.PostAsync<Post>("posts", null, new {
 				title,
@@ -189,25 +188,22 @@ namespace DiscourseApi {
 			});
 		}
 
-		static public async Task<FullTopic> Get(Api api, int topicId) {
+		public static async Task<FullTopic> Get(Api api, int topicId) {
 			return await api.GetAsync<FullTopic>(Api.Combine("t", topicId));
 		}
 
-		static public async Task<JObject> Update(Api api, int topicId, string title, int? categoryId = null) {
+		public static async Task<JObject> Update(Api api, int topicId, string title, int? categoryId = null) {
 			return await api.PutAsync(Api.Combine("t", "-", topicId), null, new {
 				title,
 				category_id = categoryId
 			});
 		}
 
-		static public async Task<JObject> ChangePostOwners(Api api, int topicId, string username, params int [] post_ids) {
+		public static async Task<JObject> ChangePostOwners(Api api, int topicId, string username, params int [] post_ids) {
 			return await api.PostAsync(Api.Combine("t", topicId, "change-owner"), null, new {
 				username,
 				post_ids
 			});
 		}
-
-	}
-
-
+    }
 }

--- a/DiscourseApi/Topic.cs
+++ b/DiscourseApi/Topic.cs
@@ -178,13 +178,14 @@ namespace DiscourseApi {
 		}
 
 		public static async Task<Post> Create(Api api, int categoryId, string title, string message, 
-				string api_username = null, DateTime? created_at = null) {
+				string api_username = null, DateTime? created_at = null, IEnumerable<string> tags = null) {
 			return await api.PostAsync<Post>("posts", null, new {
 				title,
 				category = categoryId,
 				raw = message,
 				api_username,
-				created_at
+				created_at,
+				tags
 			});
 		}
 

--- a/DiscourseApi/Topic.cs
+++ b/DiscourseApi/Topic.cs
@@ -206,5 +206,10 @@ namespace DiscourseApi {
 				post_ids
 			});
 		}
-    }
+
+        public static async Task Delete(Api api, int topicId)
+        {
+            await api.DeleteAsync(Api.Combine("t", topicId));
+        }
+	}
 }

--- a/DiscourseApi/Topic.cs
+++ b/DiscourseApi/Topic.cs
@@ -19,7 +19,7 @@ namespace DiscourseApi {
 		public int draft_sequence;
 		public int per_page;
 		public List<Topic> topics;
-	}
+    }
 
 	public class TopicListReturn : ApiEntry {
 		public List<TopicUser> users;
@@ -172,9 +172,14 @@ namespace DiscourseApi {
 		public string last_poster_username;
 		public List<JToken> posters;
 
-		public static async Task<TopicListReturn> ListAll(Api api, int categoryId, int? parentCategoryId = null) {
+		public static async Task<TopicListReturn> ListAll(Api api, int categoryId, int? parentCategoryId = null, int? page = null)
+        {
+            var categoryParam = categoryId.ToString();
+            if (page != null)
+                categoryParam += $"?page={page}";
+
 			return await api.GetAsync<TopicListReturn>(parentCategoryId > 0 ?
-				Api.Combine("c", (int)parentCategoryId, categoryId) : Api.Combine("c", categoryId));
+				Api.Combine("c", (int)parentCategoryId, categoryParam) : Api.Combine("c", categoryParam));
 		}
 
 		public static async Task<Post> Create(Api api, int categoryId, string title, string message, 


### PR DESCRIPTION
If you're having issues creating new objects via the API due to Discourse detecting your object creation as spam you can now set `Settings.SkipValidations` to true to alleviate this. This causes the `skip_validations = true` parameter to be added to posts.